### PR TITLE
Fix API json returning end_at data for the start_at field

### DIFF
--- a/app/views/api/events/_event.json.jbuilder
+++ b/app/views/api/events/_event.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract! event, :id, :group_id, :name, :image_url
 # NOTE: we're forcing RFC3339 here. What are our options to not do this?
-json.start_at event.end_at.to_datetime.rfc3339
+json.start_at event.start_at.to_datetime.rfc3339
 json.end_at event.end_at.to_datetime.rfc3339
 json.venue do
   if event.venue.present?


### PR DESCRIPTION
#### If this PR were a GIF, what would it be?
![great_scott.rb](https://media.giphy.com/media/yDCpO5cOEq1eSaM9EN/giphy.gif)

#### Description of change
The API was incorrectly returning the 'end_at' time for the 'start_at' field:
`"start_at":"2021-05-21T19:58:42+00:00","end_at":"2021-05-21T19:58:42+00:00"`
This PR corrects the issue so that 'start_at' returns the actual 'start_at' time:
`"start_at":"2021-05-21T19:58:42+00:00","end_at":"2021-05-21T19:58:42+00:00"`

#### Manual test procedure
Go to a group's events https://www.coffeecoffeecoffee.coffee/api/groups/28ef50f9-b909-4f03-9a69-a8218a8cbd99/events
Compare the start_at and end_at fields

#### Diligence checklist (omit non-applicable items):
- [x] Is a public API being changed?
  - [x] No breaking changes?
- [x] Is this code production ready?